### PR TITLE
feat: Added HomeMap and HomeWrapper for Target app

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   "license": "MIT",
   "dependencies": {
     "@formatjs/intl-relativetimeformat": "2.6.3",
+    "@monsonjeremy/react-leaflet": "3.2.2",
     "@reduxjs/toolkit": "1.4.0",
     "@rootstrap/validate": "1.0.0",
     "axios": "0.19.2",
@@ -70,6 +71,7 @@
     "humps": "2.0.1",
     "immer": "5.0.0",
     "intl": "1.2.5",
+    "leaflet": "1.7.1",
     "loaders.css": "0.1.2",
     "localforage": "1.7.3",
     "lodash": "4.17.19",

--- a/src/components/common/HomeWrapper.js
+++ b/src/components/common/HomeWrapper.js
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import HomeMap from 'components/user/HomeMap';
+
+const HomeWrapper = ({ children }) => (
+  <div className="container-fluid h-100">
+    <div className="row justify-content-center h-100">
+      <div className="col-sm-6 hidden-md-down formContainer">{children}</div>
+      <div className="bg-primary col-sm-6 col-md-6 col-lg-6 col-xl-6 ">
+        <HomeMap />
+      </div>
+    </div>
+  </div>
+);
+
+export default HomeWrapper;

--- a/src/components/user/HomeMap.js
+++ b/src/components/user/HomeMap.js
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import { MapContainer, TileLayer, Marker, Popup } from '@monsonjeremy/react-leaflet';
+import 'leaflet/dist/leaflet.css';
+
+const HomeMap = () => {
+  const position = [-34.907, -56.203];
+
+  return (
+    <div id="mapContainer">
+      <MapContainer center={position} zoom={13} scrollWheelZoom={false} style={{ height: '100vh' }}>
+        <TileLayer
+          attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        />
+        <Marker position={position}>
+          <Popup>
+            A pretty CSS3 popup. <br /> Easily customizable.
+          </Popup>
+        </Marker>
+      </MapContainer>
+    </div>
+  );
+};
+export default HomeMap;

--- a/src/routes.js
+++ b/src/routes.js
@@ -6,10 +6,12 @@ import LoginPage from 'pages/LoginPage';
 import SignUpPage from 'pages/SignUpPage';
 import NotFoundPage from 'pages/NotFoundPage';
 
+import HomeWrapper from 'components/common/HomeWrapper';
+
 const routes = [
   {
     path: routesPaths.index,
-    component: <HomePage />,
+    component: HomeWrapper(HomePage),
     exact: true,
     private: true
   },


### PR DESCRIPTION
## Links (Jira/Trello ticket and other relevant links):
https://trello.com/c/BhjNV3pq/3-3-as-a-user-i-should-be-able-to-see-a-map-so-i-can-easily-identify-targets-in-the-future

## What & Why:
Added leaflet and added a map along with a wrapper to be placed in the home page.

## Screenshots:
<img width="1437" alt="Screen Shot 2021-08-16 at 14 05 14" src="https://user-images.githubusercontent.com/78554943/129602009-61fa2174-b84a-4a6a-88d5-4a975c4e9b83.png">
